### PR TITLE
Update image versions

### DIFF
--- a/env.example
+++ b/env.example
@@ -14,7 +14,7 @@ RESTART_POLICY=unless-stopped
 ## Please keep in mind this will create a superuser and it's recommended to use a less privileged
 ## user to connect to the database.
 #TODO: add link to user migration guide
-POSTGRES_IMAGE_TAG=alpine
+POSTGRES_IMAGE_TAG=13-alpine
 POSTGRES_DATA_PATH=./volumes/db/var/lib/postgresql/data
 
 POSTGRES_USER=mmuser
@@ -55,7 +55,7 @@ MATTERMOST_CLIENT_PLUGINS_PATH=./volumes/app/mattermost/client-plugins
 
 ## This will be 'mattermost-enterprise-edition' or 'mattermost-team-edition' based on the version of Mattermost you're installing.
 MATTERMOST_IMAGE=mattermost-enterprise-edition
-MATTERMOST_IMAGE_TAG=5.34
+MATTERMOST_IMAGE_TAG=5.36
 
 ## The app port is only relevant for using Mattermost without the nginx container as reverse proxy. This is not meant
 ## to be used with the internal HTTP server exposed but rather in case one wants to host several services on one host


### PR DESCRIPTION
Setting Postgres to a major release tag will ensure there are not
suprises while autoupdates.