### PR TITLE
Fix references to steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sudo systemctl enable --now docker
 ```
 
 ### 5. Placing the certificate and key (if using provided nginx)
-Use either 4.1 or 4.2 for setting up SSL. Both methods require you to change the path to the Let's Encrypt config folders inside the *.env*. 
+Use either 5.1 or 5.2 for setting up SSL. Both methods require you to change the path to the Let's Encrypt config folders inside the *.env*. 
 
 
 #### 5.1 Pre-existing certificate and key


### PR DESCRIPTION
#### Summary

The README mentions that it's possible to do either step `4.1` or `4.2` to set up the certificate, but the references are outdated­. It should be `5.1` or `5.2`.

#### Ticket Link

n/a
