### PR TITLE
fixes to 5.38.2

### DIFF
--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -12,7 +12,7 @@ services:
     pids_limit: 100
     read_only: true
     tmpfs:
-      - /var/run
+      - /run
       - /var/cache
       - /var/log/nginx
     volumes:
@@ -23,7 +23,7 @@ services:
       - shared-webroot:/usr/share/nginx/html
     environment:
       # timezone inside container
-      - TZ
+      - ${TZ}
     ports:
       - ${HTTPS_PORT}:443
       - ${HTTP_PORT}:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,12 @@ services:
     read_only: true
     tmpfs:
       - /tmp
-      - /var/run/postgresql
+      - /run/postgresql
     volumes:
       - ${POSTGRES_DATA_PATH}:/var/lib/postgresql/data
     environment:
       # timezone inside container
-      - TZ
+      - ${TZ}
 
       # necessay Postgres options/variables
       - POSTGRES_USER
@@ -34,18 +34,19 @@ services:
     security_opt:
       - no-new-privileges:true
     pids_limit: 200
-    read_only: true
+    read_only: false
     tmpfs:
       - /tmp
     volumes:
       - ${MATTERMOST_CONFIG_PATH}:/mattermost/config:rw
       - ${MATTERMOST_DATA_PATH}:/mattermost/data:rw
+      - ${MATTERMOST_BLEVE_PATH}:/mattermost/bleveindexes:rw
       - ${MATTERMOST_LOGS_PATH}:/mattermost/logs:rw
       - ${MATTERMOST_PLUGINS_PATH}:/mattermost/plugins:rw
       - ${MATTERMOST_CLIENT_PLUGINS_PATH}:/mattermost/client/plugins:rw
     environment:
       # timezone inside container
-      - TZ
+      - ${TZ}
 
       # necessary Mattermost options/variables (see env.example)
       - MM_SQLSETTINGS_DRIVERNAME

--- a/env.example
+++ b/env.example
@@ -49,6 +49,7 @@ HTTP_PORT=80
 ## `sudo chown -R 2000:2000 ./volumes/app/mattermost`.
 MATTERMOST_CONFIG_PATH=./volumes/app/mattermost/config
 MATTERMOST_DATA_PATH=./volumes/app/mattermost/data
+MATTERMOST_BLEVE_PATH=./volumes/app/mattermost/bleveindexes
 MATTERMOST_LOGS_PATH=./volumes/app/mattermost/logs
 MATTERMOST_PLUGINS_PATH=./volumes/app/mattermost/plugins
 MATTERMOST_CLIENT_PLUGINS_PATH=./volumes/app/mattermost/client/plugins


### PR DESCRIPTION
#### Summary
I was upgrading my 5.37 that was built on former "mattermost-docker" repo (upgraded Postgres with the script manually sometimes about 5.32 or so). Faced several issues that prevented me from running it successfully

Changes are somewhat obvious:

1. change "-TZ" to "-${TZ}" as the variable is defined in the .env (probably that was original intention)
2. change /var/run to /run: in current containers that I pulled it is a symlink, so when running you get "readonly filesystem error" since "tmpfs" does not work with symlinks
3. added BLEVE_PATH, since I have Bleve catalog in volumes - otherwise I also got "readonly filesystem" error for that Bleve init.
4. changed "read_only" to "false" in mattermost container, since there was
`{"level":"error","ts":1630607829.132162,"caller":"web/static.go:26","msg":"Failed to update assets subpath from config","error":"failed to update root.html with subpath /: open /mattermo
st/client/root.html: read-only file system","errorVerbose":"open /mattermost/client/root.html: read-only file system\nfailed to update root.html with subpath /\ngithub.com/mattermost/mat
termost-server/v5/utils.UpdateAssetsSubpathInDir\n\tgithub.com/mattermost/mattermost-server/v5/utils/subpath.go:117\ngithub.com/mattermost/mattermost-server/v5/utils.UpdateAssetsSubpath\
n\tgithub.com/mattermost/mattermost-server/v5/utils/subpath.go:145\ngithub.com/mattermost/mattermost-server/v5/utils.UpdateAssetsSubpathFromConfig\n\tgithub.com/mattermost/mattermost-ser
ver/v5/utils/subpath.go:168\ngithub.com/mattermost/mattermost-server/v5/web.(*Web).InitStatic\n\tgithub.com/mattermost/mattermost-server/v5/web/static.go:25\ngithub.com/mattermost/matter
most-server/v5/web.New\n\tgithub.com/mattermost/mattermost-server/v5/web/web.go:36\ngithub.com/mattermost/mattermost-server/v5/cmd/mattermost/commands.runServer\n\tgithub.com/mattermost/
mattermost-server/v5/cmd/mattermost/commands/server.go:100\ngithub.com/mattermost/mattermost-server/v5/cmd/mattermost/commands.serverCmdF\n\tgithub.com/mattermost/mattermost-server/v5/cm
d/mattermost/commands/server.go:58\ngithub.com/spf13/cobra.(*Command).execute\n\tgithub.com/spf13/cobra@v1.1.3/command.go:852\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\tgithub.com/sp
f13/cobra@v1.1.3/command.go:960\ngithub.com/spf13/cobra.(*Command).Execute\n\tgithub.com/spf13/cobra@v1.1.3/command.go:897\ngithub.com/mattermost/mattermost-server/v5/cmd/mattermost/comm
ands.Run\n\tgithub.com/mattermost/mattermost-server/v5/cmd/mattermost/commands/root.go:14\nmain.main\n\tgithub.com/mattermost/mattermost-server/v5/cmd/mattermost/main.go:31\nruntime.main
\n\truntime/proc.go:225\nruntime.goexit\n\truntime/asm_amd64.s:1371"}
`