### PR TITLE
Make readonly container overwritable, defaults to false

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     security_opt:
       - no-new-privileges:true
     pids_limit: 200
-    read_only: true
+    read_only: ${MATTERMOST_CONTAINER_READONLY}
     tmpfs:
       - /tmp
     volumes:

--- a/env.example
+++ b/env.example
@@ -57,6 +57,11 @@ MATTERMOST_CLIENT_PLUGINS_PATH=./volumes/app/mattermost/client/plugins
 MATTERMOST_IMAGE=mattermost-enterprise-edition
 MATTERMOST_IMAGE_TAG=5.38
 
+## Make Mattermost container readonly. This interferes with the regeneration of root.html inside the container. Only use
+## it if you know what you're doing.
+## See https://github.com/mattermost/docker/issues/18
+MATTERMOST_CONTAINER_READONLY=false
+
 ## The app port is only relevant for using Mattermost without the nginx container as reverse proxy. This is not meant
 ## to be used with the internal HTTP server exposed but rather in case one wants to host several services on one host
 ## or for using it behind another existing reverse proxy.


### PR DESCRIPTION
#### Summary
Starting the Mattermost container read-only leads to an error because the root.html in the clients directory can't be regenerated. With the change the default behaviour is to disable readonly but can be enabled is desired.

