### PR TITLE
Fix timezone typo refs: https://github.com/mattermost/docker/issues/56

### DIFF
--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -27,7 +27,7 @@ services:
       # - ${GITLAB_PKI_CHAIN_PATH}:/etc/ssl/certs/pki_chain.pem:ro
     environment:
       # timezone inside container
-      - TZ: ${TZ}
+      - TZ
     ports:
       - ${HTTPS_PORT}:443
       - ${HTTP_PORT}:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ${POSTGRES_DATA_PATH}:/var/lib/postgresql/data
     environment:
       # timezone inside container
-      - TZ: ${TZ}
+      - TZ
 
       # necessary Postgres options/variables
       - POSTGRES_USER
@@ -45,7 +45,7 @@ services:
       - ${MATTERMOST_CLIENT_PLUGINS_PATH}:/mattermost/client/plugins:rw
     environment:
       # timezone inside container
-      - TZ: ${TZ}
+      - TZ
 
       # necessary Mattermost options/variables (see env.example)
       - MM_SQLSETTINGS_DRIVERNAME


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Hello @metanerd ,
This issue is to fix a typo in `docker-compose.yml` and `docker-compose.nginx.yml` introduced in my previous PR #52.
I'm very sorry for this typo in the push.

I ran `docker-compose -f docker-compose.yml -f docker-compose.nginx.yml config` to validate and I can see that the environment variable `TZ` is correctly interpolate.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/docker/issues/56
