### PR TITLE
Fix bad location for GITLAB_PKI_CHAIN_PATH option

### DIFF
--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -21,10 +21,6 @@ services:
       - ${CERT_PATH}:/cert.pem:ro
       - ${KEY_PATH}:/key.pem:ro
       - shared-webroot:/usr/share/nginx/html
-      # When you want to use SSO with GitLab, you have to add the cert pki chain of GitLab inside Alpine
-      # to avoid Token request failed: certificate signed by unknown authority 
-      # (link: https://github.com/mattermost/mattermost-server/issues/13059 and https://github.com/mattermost/docker/issues/34)
-      # - ${GITLAB_PKI_CHAIN_PATH}:/etc/ssl/certs/pki_chain.pem:ro
     environment:
       # timezone inside container
       - TZ

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,10 @@ services:
       - ${MATTERMOST_LOGS_PATH}:/mattermost/logs:rw
       - ${MATTERMOST_PLUGINS_PATH}:/mattermost/plugins:rw
       - ${MATTERMOST_CLIENT_PLUGINS_PATH}:/mattermost/client/plugins:rw
+      # When you want to use SSO with GitLab, you have to add the cert pki chain of GitLab inside Alpine
+      # to avoid Token request failed: certificate signed by unknown authority 
+      # (link: https://github.com/mattermost/mattermost-server/issues/13059 and https://github.com/mattermost/docker/issues/34)
+      # - ${GITLAB_PKI_CHAIN_PATH}:/etc/ssl/certs/pki_chain.pem:ro
     environment:
       # timezone inside container
       - TZ


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Here is the pull request to fix the issue I open about missing code that I already PR in the previous repository.

This PR is to fix a wrong location commited in https://github.com/mattermost/docker/pull/52

I'm using it in Production and the right place is in `docker-compose.yml` not in `docker-compose.nginx.yml`

@hanzei Please could you ask for a review ?

@metanerd, @cpanato, @mrckndt Please could you have a look into this one ?

Thank you very much and sorry for the mistake

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/docker/issues/34
_Originally posted by @craph in https://github.com/mattermost/mattermost-docker/pull/529#issuecomment-912340798_