### PR TITLE
Save Bleve indexes to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ MATTERMOST_IMAGE_TAG=5.36
 
 ### 3. Create the needed directores and set permissions (this orientates on the previous *mattermost-docker* structure and the direcories can be changed in the *.env* file)
 ```
-mkdir -p ./volumes/app/mattermost/{config,data,logs,plugins,client/plugins}
+mkdir -p ./volumes/app/mattermost/{config,data,logs,plugins,client/plugins,bleve-indexes}
 sudo chown -R 2000:2000 ./volumes/app/mattermost
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - ${MATTERMOST_LOGS_PATH}:/mattermost/logs:rw
       - ${MATTERMOST_PLUGINS_PATH}:/mattermost/plugins:rw
       - ${MATTERMOST_CLIENT_PLUGINS_PATH}:/mattermost/client/plugins:rw
+      - ${MATTERMOST_BLEVE_INDEXES_PATH}:/mattermost/bleve-indexes:rw
       # When you want to use SSO with GitLab, you have to add the cert pki chain of GitLab inside Alpine
       # to avoid Token request failed: certificate signed by unknown authority 
       # (link: https://github.com/mattermost/mattermost-server/issues/13059 and https://github.com/mattermost/docker/issues/34)
@@ -54,6 +55,9 @@ services:
       # necessary Mattermost options/variables (see env.example)
       - MM_SQLSETTINGS_DRIVERNAME
       - MM_SQLSETTINGS_DATASOURCE
+
+      # necessary for bleve
+      - MM_BLEVESETTINGS_INDEXDIR
 
       # additional settings
       - MM_SERVICESETTINGS_SITEURL

--- a/env.example
+++ b/env.example
@@ -53,6 +53,10 @@ MATTERMOST_DATA_PATH=./volumes/app/mattermost/data
 MATTERMOST_LOGS_PATH=./volumes/app/mattermost/logs
 MATTERMOST_PLUGINS_PATH=./volumes/app/mattermost/plugins
 MATTERMOST_CLIENT_PLUGINS_PATH=./volumes/app/mattermost/client/plugins
+MATTERMOST_BLEVE_INDEXES_PATH=./volumes/app/mattermost/bleve-indexes
+
+## Bleve index (inside the container)
+MM_BLEVESETTINGS_INDEXDIR=/mattermost/bleve-indexes
 
 ## This will be 'mattermost-enterprise-edition' or 'mattermost-team-edition' based on the version of Mattermost you're installing.
 MATTERMOST_IMAGE=mattermost-enterprise-edition


### PR DESCRIPTION
#### Summary
This commit adds the possibility to keep Bleve indexes persistent on disk instead of just inside the currently running Mattermost container.