### PR TITLE
Remove container_names from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ version: "2.4"
 
 services:
   postgres:
-    container_name: postgres_mattermost
     image: postgres:${POSTGRES_IMAGE_TAG}
     restart: ${RESTART_POLICY}
     security_opt:
@@ -28,7 +27,6 @@ services:
   mattermost:
     depends_on:
       - postgres
-    container_name: mattermost
     image: mattermost/${MATTERMOST_IMAGE}:${MATTERMOST_IMAGE_TAG}
     restart: ${RESTART_POLICY}
     security_opt:


### PR DESCRIPTION
#### Summary
In environments with multiple instances on one server there are nameconflicts by setting container names in docker-compose.yml. Is there any reason why they are hardcoded?
If not it would be great to remove the container_names from docker-compose.yml by accepting this PR.


