### PR TITLE
update version tag to point to latest ESR

### DIFF
--- a/env.example
+++ b/env.example
@@ -60,7 +60,7 @@ MM_BLEVESETTINGS_INDEXDIR=/mattermost/bleve-indexes
 
 ## This will be 'mattermost-enterprise-edition' or 'mattermost-team-edition' based on the version of Mattermost you're installing.
 MATTERMOST_IMAGE=mattermost-enterprise-edition
-MATTERMOST_IMAGE_TAG=5.39
+MATTERMOST_IMAGE_TAG=6.3
 
 ## Make Mattermost container readonly. This interferes with the regeneration of root.html inside the container. Only use
 ## it if you know what you're doing.


### PR DESCRIPTION
This PR updates the version tag in the example file to use 6.3 which is the current extended support release which will be supported until later this year. 