### PR TITLE
Update docker-compose.yml: Increased pid_limit and added mem_limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,10 @@ services:
     restart: ${RESTART_POLICY}
     security_opt:
       - no-new-privileges:true
-    pids_limit: 200
+    pids_limit: 500
+    mem_reservation: 2G
+    mem_limit: 8G
+    memswap_limit: 2G
     read_only: ${MATTERMOST_CONTAINER_READONLY}
     tmpfs:
       - /tmp


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->

- Increased pid_limit to mattermost container which low value caused vary plugin crashes and unableing to use mmctl inside container

_Commentary:_ In case of our mattermost server I can track by `systemd-cgtop` command that mattermost container using over 200 tasks. This low value on pid_limit caused vary plugins crashing accidentially and failing container healthcheck. This issues was very hard to investigate. I only discover this when I was needed to use `mmctl` and I was unable to run binary inside container with next error:
```
runtime/cgo: runtime/cgo: pthread_create failed: Resource temporarily unavailablepthread_create failed: Resource temporarily unavailable
```
- Added memory limitation to mattermost container for preventing potential memory leaks

_Commentary:_ This limitations were added to our mattermost server after several memory leaks during last year. Before upgrading to 7.1.3 several leaks was caused by mention 100+ users over @all command in channel, but this already fixed afaik. Recent leak that was on latest LTS 7.1.3 relase we ain't determined but we guessing it caused by playbooks plugin beacause of a lot of errors on consumtion memory peak.

Hope this information can help someone.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

