### PR TITLE
Expose port to enable Calls connectivity

### DIFF
--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -27,6 +27,9 @@ services:
     ports:
       - ${HTTPS_PORT}:443
       - ${HTTP_PORT}:80
+  mattermost:
+    ports:
+      - ${CALLS_PORT}:8443/udp
 
 # Shared volume for Let's Encrypt certificate renewal with a webroot
 volumes:

--- a/docker-compose.without-nginx.yml
+++ b/docker-compose.without-nginx.yml
@@ -4,3 +4,4 @@ services:
   mattermost:
     ports:
       - ${APP_PORT}:8065
+      - ${CALLS_PORT}:8443/udp

--- a/env.example
+++ b/env.example
@@ -41,9 +41,10 @@ KEY_PATH=./volumes/web/cert/key-no-password.pem
 #CERT_PATH=./certs/etc/letsencrypt/live/${DOMAIN}/fullchain.pem
 #KEY_PATH=./certs/etc/letsencrypt/live/${DOMAIN}/privkey.pem
 
-## Exposed ports to the host. Inside the container 80 and 443 will be used
+## Exposed ports to the host. Inside the container 80, 443 and 8443 will be used
 HTTPS_PORT=443
 HTTP_PORT=80
+CALLS_PORT=8443
 
 # Mattermost settings
 ## Inside the container the uid and gid is 2000. The folder owner can be set with


### PR DESCRIPTION
#### Summary

PR adds the necessary configuration to expose the WebRTC (udp based) port (`8443`) that Mattermost Calls uses for connectivity. Since we are going GA it makes sense to make this change as it removes some burden on the users given the feature is supposed to be enabled by default now.

I tested both cases (with and without nginx) by following https://docs.mattermost.com/install/install-docker.html#deploy-mattermost-on-docker-for-production-use and got everything working correctly once configured accordingly.
