### PR TITLE
[default.conf] Use X-Robots-Tag, not robots.txt

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -85,10 +85,7 @@ server {
     }
 
     # disable Google bots from indexing this site
-    location = /robots.txt {
-        add_header Content-Type text/plain;
-        return 200 "User-agent: *\nDisallow: /\n";
-    }
+    add_header X-Robots-Tag "noindex";
 
     location ~ /api/v[0-9]+/(users/)?websocket$ {
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
#### Summary

Google recommends now-a-days we use `X-Robots-Tag`, not a robots.txt file.

https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#xrobotstag

https://developers.google.com/search/docs/crawling-indexing/robots/intro

> A robots.txt file tells search engine crawlers which URLs the crawler can access on your site. This is used mainly to avoid overloading your site with requests; it is not a mechanism for keeping a web page out of Google. To keep a web page out of Google, [block indexing with noindex](https://developers.google.com/search/docs/crawling-indexing/block-indexing) or password-protect the page.
