### PR TITLE
[without-ssl-conf.d] Add default.conf without ssl termination option

### DIFF
--- a/nginx/without-ssl-conf.d/default.conf
+++ b/nginx/without-ssl-conf.d/default.conf
@@ -1,0 +1,100 @@
+###########
+
+# mattermost
+# This configuration file is for use by people behind some load balancer which already terminates SSL
+# where the user may desire not to use backend letsencrypt SSL within a secured network.
+
+# proxy cache
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=mattermost_cache:10m max_size=3g inactive=120m use_temp_path=off;
+
+# upstream used in proxy_pass below
+upstream backend {
+    # ip where Mattermost is running; this relies on a working DNS inside the Docker network
+    # and uses the hostname of the mattermost container (see service name in docker-compose.yml)
+    server mattermost:8065;
+    keepalive 64;
+}
+
+server {
+    server_name _;
+    listen 80;
+    listen [::]:80;
+
+    # logging
+    access_log /var/log/nginx/mm.access.log;
+    error_log /var/log/nginx/mm.error.log warn;
+
+    # gzip for performance
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+
+    ## security headers
+    # https://securityheaders.com/
+    # https://scotthelme.co.uk/tag/security-headers/
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy no-referrer;
+    add_header Strict-Transport-Security "max-age=63072000" always;
+    add_header Permissions-Policy "interest-cohort=()";
+
+    ## locations
+    # ACME-challenge
+    location ^~ /.well-known {
+        default_type "text/plain";
+        root /usr/share/nginx/html;
+        allow all;
+    }
+
+    # disable Google bots from indexing this site
+    location = /robots.txt {
+        add_header Content-Type text/plain;
+        return 200 "User-agent: *\nDisallow: /\n";
+    }
+
+    location ~ /api/v[0-9]+/(users/)?websocket$ {
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        client_max_body_size 50M;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Frame-Options SAMEORIGIN;
+        proxy_set_header Early-Data $ssl_early_data;
+        proxy_buffers 256 16k;
+        proxy_buffer_size 16k;
+        client_body_timeout 60;
+        send_timeout 300;
+        lingering_timeout 5;
+        proxy_connect_timeout 90;
+        proxy_send_timeout 300;
+        proxy_read_timeout 90s;
+        proxy_http_version 1.1;
+        proxy_pass http://backend;
+    }
+
+    location / {
+        client_max_body_size 50M;
+        proxy_set_header Connection "";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Frame-Options SAMEORIGIN;
+        proxy_set_header Early-Data $ssl_early_data;
+        proxy_buffers 256 16k;
+        proxy_buffer_size 16k;
+        proxy_read_timeout 600s;
+        proxy_cache mattermost_cache;
+        proxy_cache_revalidate on;
+        proxy_cache_min_uses 2;
+        proxy_cache_use_stale timeout;
+        proxy_cache_lock on;
+        proxy_http_version 1.1;
+        proxy_pass http://backend;
+    }
+}


### PR DESCRIPTION
#### Summary

Hello, for users who already have SSL termination via some load balancer within a secured VPC, it might be helpful to provide an nginx configuration option for them.

This can be [optionally, not used by default] used by those who desire it, by changing in `.env` the following var  `NGINX_CONFIG_PATH=`

Original,

`NGINX_CONFIG_PATH=./nginx/conf.d`

Modified, for those who do not want backend SSL,

`NGINX_CONFIG_PATH=./nginx/without-ssl-conf.d`