### PR TITLE
Update env.example

### DIFF
--- a/1-click-install-without-nginx.sh
+++ b/1-click-install-without-nginx.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Update system
+sudo apt update && sudo apt upgrade -y
+sudo apt install curl build-essential git wget jq make gcc ack tmux ncdu -y
+sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.27.3/yq_linux_amd64 && chmod +x /usr/local/bin/yq
+
+# install docker
+apt update && apt install git sudo unzip wget -y
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+curl -SL https://github.com/docker/compose/releases/download/v2.5.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+
+#
+cp env.example .env
+mkdir -p ./volumes/app/mattermost/{config,data,logs,plugins,client/plugins,bleve-indexes}
+sudo chown -R 2000:2000 ./volumes/app/mattermost
+
+sudo docker-compose -f docker-compose.yml -f docker-compose.without-nginx.yml up -d
+
+

--- a/env.example
+++ b/env.example
@@ -61,7 +61,7 @@ MM_BLEVESETTINGS_INDEXDIR=/mattermost/bleve-indexes
 
 ## This will be 'mattermost-enterprise-edition' or 'mattermost-team-edition' based on the version of Mattermost you're installing.
 MATTERMOST_IMAGE=mattermost-enterprise-edition
-MATTERMOST_IMAGE_TAG=7.1
+MATTERMOST_IMAGE_TAG=latest
 
 ## Make Mattermost container readonly. This interferes with the regeneration of root.html inside the container. Only use
 ## it if you know what you're doing.

--- a/restart-mm-docker.sh
+++ b/restart-mm-docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+sudo docker-compose -f docker-compose.yml -f docker-compose.nginx.yml down
+sleep 5
+sudo docker-compose -f docker-compose.yml -f docker-compose.nginx.yml up -d

--- a/restart-mm-docker.sh
+++ b/restart-mm-docker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+sudo apt update && sudo apt upgrade -y
 sudo docker-compose -f docker-compose.yml -f docker-compose.nginx.yml down
 sleep 5
 sudo docker-compose -f docker-compose.yml -f docker-compose.nginx.yml up -d


### PR DESCRIPTION
Could we always use the latest docker image?