### PR TITLE
Ignore docker compose override file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ volumes
 data
 certs
 .env
+docker-compose.override.yml
+docker-compose.override.yaml


### PR DESCRIPTION
#### Summary

It would be nice to ignore `docker-compose.override.y(a)ml` so we can override the versioned `docker-compose.yml` without modifying it or being told by git that `docker-compose.override.yml` is an untracked file.

#### Use case

I use `docker-compose.override.y(a)ml` to add labels to the mattermost container in order to configure Traefik

#### Related resource

https://docs.docker.com/compose/extends/
