### PR TITLE
Expose Calls UDP port in base compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,8 @@ services:
 
       # additional settings
       - MM_SERVICESETTINGS_SITEURL
+    ports:
+      - ${CALLS_PORT}:8443/udp
 
 # If you use rolling image tags and feel lucky watchtower can automatically pull new images and
 # instantiate containers from it. https://containrrr.dev/watchtower/


### PR DESCRIPTION
#### Summary

Similarly to https://github.com/mattermost/docker/pull/113 we are exposing the Calls UDP port in the base docker compose file as some users have struggled to achieve connectivity as they were not using either `docker-compose.nginx.yml` nor `docker-compose.without-nginx.yml`.

https://forum.mattermost.com/t/calls-plugin-does-not-work-on-mobile-network/15538 for more context on the reported issue.