### PR TITLE
Expose TCP port for Calls

### DIFF
--- a/docker-compose.without-nginx.yml
+++ b/docker-compose.without-nginx.yml
@@ -5,3 +5,4 @@ services:
     ports:
       - ${APP_PORT}:8065
       - ${CALLS_PORT}:8443/udp
+      - ${CALLS_PORT}:8443/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - MM_SERVICESETTINGS_SITEURL
     ports:
       - ${CALLS_PORT}:8443/udp
+      - ${CALLS_PORT}:8443/tcp
 
 # If you use rolling image tags and feel lucky watchtower can automatically pull new images and
 # instantiate containers from it. https://containrrr.dev/watchtower/

--- a/env.example
+++ b/env.example
@@ -61,7 +61,7 @@ MM_BLEVESETTINGS_INDEXDIR=/mattermost/bleve-indexes
 
 ## This will be 'mattermost-enterprise-edition' or 'mattermost-team-edition' based on the version of Mattermost you're installing.
 MATTERMOST_IMAGE=mattermost-enterprise-edition
-MATTERMOST_IMAGE_TAG=7.1
+MATTERMOST_IMAGE_TAG=7.8
 
 ## Make Mattermost container readonly. This interferes with the regeneration of root.html inside the container. Only use
 ## it if you know what you're doing.


### PR DESCRIPTION
#### Summary

Starting from next Calls release we are enabling support for TCP candidates. This means that if no UDP connection is possible, a TCP channel can be used instead as a backup option. The big advantage of this approach is that it can avoid having to deploy and maintain a separate TURN server to guarantee connectivity for clients unable to use UDP for whatever reason (e.g. protocol blocked by firewall).

I am also updating the base image version to the latest ESR since support for the previous one has ended last month.
