### PR TITLE
Use Compose Specification

### DIFF
--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   nginx:
     depends_on:

--- a/docker-compose.without-nginx.yml
+++ b/docker-compose.without-nginx.yml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   mattermost:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,4 @@
 # https://docs.docker.com/compose/environment-variables/
-
-version: "2.4"
-
 services:
   postgres:
     image: postgres:${POSTGRES_IMAGE_TAG}


### PR DESCRIPTION
#### Summary
Legacy versions 2.x and 3.x of the Compose file format were merged into the Compose Specification. It is implemented in versions 1.27.0 and above (also known as Compose V2) of the Docker Compose CLI.

See https://docs.docker.com/compose/compose-file/

#### Ticket Link
-
