### PR TITLE
[GH-128] Removed problematic `security_opt`: `no-new-privileges`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
   postgres:
     image: postgres:${POSTGRES_IMAGE_TAG}
     restart: ${RESTART_POLICY}
-    security_opt:
-      - no-new-privileges:true
     pids_limit: 100
     read_only: true
     tmpfs:
@@ -29,8 +27,6 @@ services:
       - postgres
     image: mattermost/${MATTERMOST_IMAGE}:${MATTERMOST_IMAGE_TAG}
     restart: ${RESTART_POLICY}
-    security_opt:
-      - no-new-privileges:true
     pids_limit: 200
     read_only: ${MATTERMOST_CONTAINER_READONLY}
     tmpfs:


### PR DESCRIPTION
#### Summary

This pull request removes the `no-new-privileges` `security_opt` from the services defined in the /docker-compose.yml file, as it causes errors when attempting to start the containers (see #128). Removing the security option seems to resolve the problem.

#### Ticket Link

Fixes https://github.com/mattermost/docker/issues/128