### PR TITLE
Support custom port for Calls

### DIFF
--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -29,7 +29,8 @@ services:
       - ${HTTP_PORT}:80
   mattermost:
     ports:
-      - ${CALLS_PORT}:8443/udp
+      - ${CALLS_PORT}:${CALLS_PORT}/udp
+      - ${CALLS_PORT}:${CALLS_PORT}/tcp
 
 # Shared volume for Let's Encrypt certificate renewal with a webroot
 volumes:

--- a/docker-compose.without-nginx.yml
+++ b/docker-compose.without-nginx.yml
@@ -4,5 +4,5 @@ services:
   mattermost:
     ports:
       - ${APP_PORT}:8065
-      - ${CALLS_PORT}:8443/udp
-      - ${CALLS_PORT}:8443/tcp
+      - ${CALLS_PORT}:${CALLS_PORT}/udp
+      - ${CALLS_PORT}:${CALLS_PORT}/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,9 +59,6 @@ services:
 
       # additional settings
       - MM_SERVICESETTINGS_SITEURL
-    ports:
-      - ${CALLS_PORT}:8443/udp
-      - ${CALLS_PORT}:8443/tcp
 
 # If you use rolling image tags and feel lucky watchtower can automatically pull new images and
 # instantiate containers from it. https://containrrr.dev/watchtower/


### PR DESCRIPTION
#### Summary

I realized that the way this was set we weren't really supporting anything other than the default `8443`. Now we rewrite the port on both sides so that it's forwarded correctly.



