### PR TITLE
fix(nginx): Use new http2 directive

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -25,8 +25,9 @@ server {
 
 server {
     server_name _;
-    listen 443 ssl http2 default_server;
-    listen [::]:443 ssl http2 default_server;
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    http2 on;
 
     # logging
     access_log /var/log/nginx/mm.access.log;


### PR DESCRIPTION
#### Summary

This updates the nginx configuration to use the new `http2` directive.

> The http2 parameter of the listen directive is deprecated, the [http2](https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2) directive should be used instead.

The `http2` directive appeared in version 1.25.1. 

