### PR TITLE
Document nginx 1.25.1 requirement

### DIFF
--- a/env.example
+++ b/env.example
@@ -29,6 +29,7 @@ POSTGRES_DB=mattermost
 
 ## Inside the container the uid and gid is 101. The folder owner can be set with
 ## `sudo chown -R 101:101 ./nginx` if needed.
+## Note that this repository requires nginx version 1.25.1 or later
 NGINX_IMAGE_TAG=alpine
 
 ## The folder containing server blocks and any additional config to nginx.conf


### PR DESCRIPTION
#### Summary

PR https://github.com/mattermost/docker/pull/146 has introduced a change that requires nginx version 1.25.1, or more recent, to be used.
To avoid confusing users, we should document this requirement.
