### PR TITLE
chore(deps): upgrade to postgres 18 and latest mattermost patch release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - /tmp
       - /var/run/postgresql
     volumes:
-      - ${POSTGRES_DATA_PATH}:/var/lib/postgresql/data
+      - ${POSTGRES_DATA_PATH}:/var/lib/postgresql
     environment:
       # timezone inside container
       - TZ

--- a/env.example
+++ b/env.example
@@ -14,7 +14,7 @@ RESTART_POLICY=unless-stopped
 ## Please keep in mind this will create a superuser and it's recommended to use a less privileged
 ## user to connect to the database.
 ## A guide on how to change the database user to a nonsuperuser can be found in docs/creation-of-nonsuperuser.md
-POSTGRES_IMAGE_TAG=14-alpine
+POSTGRES_IMAGE_TAG=18-alpine
 POSTGRES_DATA_PATH=./volumes/db/var/lib/postgresql/data
 
 POSTGRES_USER=mmuser
@@ -63,7 +63,7 @@ MM_BLEVESETTINGS_INDEXDIR=/mattermost/bleve-indexes
 ## This will be 'mattermost-enterprise-edition' or 'mattermost-team-edition' based on the version of Mattermost you're installing.
 MATTERMOST_IMAGE=mattermost-enterprise-edition
 ## Update the image tag if you want to upgrade your Mattermost version. You may also upgrade to the latest one. The example is based on the latest Mattermost ESR version.
-MATTERMOST_IMAGE_TAG=10.11.5
+MATTERMOST_IMAGE_TAG=10.11.8
 
 ## Make Mattermost container readonly. This interferes with the regeneration of root.html inside the container. Only use
 ## it if you know what you're doing.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This revision bumps postgres from version 14 to the latest supported release, version 18. In version 18, the format of the persistent storage volume changed to improve ease of database upgrades. To accomodate this, the volume mounts for the postgres service in docker compose was adjusted. Refer to the upstream documentation for more details.

Additionally, mattermost was upgraded to the latest patch release 10.11.7 which includes some low- to medium-severity security fixes.

I've tested this in my personal environment for a few weeks, works well :-)

#### Ticket Link

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

None.