### PR TITLE
FIX: docker-compose.without-nginx.yml

### DIFF
--- a/docker-compose.without-nginx.yml
+++ b/docker-compose.without-nginx.yml
@@ -2,5 +2,5 @@ services:
   mattermost:
     ports:
       - ${APP_PORT}:8065
-      - ${CALLS_PORT}:${CALLS_PORT}/udp
-      - ${CALLS_PORT}:${CALLS_PORT}/tcp
+      - ${CALLS_PORT}:8443/udp
+      - ${CALLS_PORT}:8443/tcp


### PR DESCRIPTION
#### Summary
Updated the Mattermost Calls service port configuration to properly map the container's internal port 8443 to a custom host port. Previously, the configuration used ${CALLS_PORT} for both host and container ports, which incorrectly assumed the host and container ports should be the same. The container always uses port 8443 internally for the Calls service, so this fix ensures proper mapping by introducing ${CALLS_PORT} for the external host port while keeping the container port fixed at 8443.