### PR TITLE
Replace pids_limit with memory limits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,9 @@ services:
     restart: ${RESTART_POLICY}
     security_opt:
       - no-new-privileges:true
-    pids_limit: 100
+    # See https://docs.mattermost.com/administration-guide/scale/scaling-for-enterprise.html
+    # for guidance on memory limits based on your deployment size.
+    mem_limit: 16G
     read_only: true
     tmpfs:
       - /tmp
@@ -28,7 +30,9 @@ services:
     restart: ${RESTART_POLICY}
     security_opt:
       - no-new-privileges:true
-    pids_limit: 200
+    # See https://docs.mattermost.com/administration-guide/scale/scaling-for-enterprise.html
+    # for guidance on memory limits based on your deployment size.
+    mem_limit: 4G
     read_only: ${MATTERMOST_CONTAINER_READONLY}
     tmpfs:
       - /tmp


### PR DESCRIPTION
## Summary

Replace `pids_limit` with `mem_limit` for postgres and mattermost services to prevent connection failures under normal load.

## Problem

A customer reported PostgreSQL connection failures caused by hitting the `pids_limit: 100` constraint. PostgreSQL creates one process per database connection, meaning the database could only handle ~90-95 concurrent connections before exhausting the PID limit. This is too restrictive for production deployments with moderate traffic.

## Changes

- **postgres service**: Removed `pids_limit: 100`, added `mem_limit: 16G`
- **mattermost service**: Removed `pids_limit: 200`, added `mem_limit: 4G`
- Added inline comments directing users to enterprise scaling documentation for sizing guidance

## Rationale

Memory limits provide better resource protection while allowing PostgreSQL to scale connections naturally based on actual load. The `pids_limit` approach was overly restrictive and caused operational issues in real-world scenarios.

The default values chosen (16G/4G) are based on typical medium-sized deployment requirements and can be adjusted per the scaling documentation.

## Documentation

Inline comments added referencing https://docs.mattermost.com/administration-guide/scale/scaling-for-enterprise.html