### PR TITLE
nginx: allow large file uploads for /api/v4/files endpoint

### DIFF
--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -110,23 +110,8 @@ server {
         proxy_pass http://backend;
     }
 
-    location = /api/v4/files {
-        client_max_body_size 0;
-        client_body_timeout 1200s;
-        proxy_set_header Connection "";
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Frame-Options SAMEORIGIN;
-        proxy_set_header Early-Data $ssl_early_data;
-        proxy_read_timeout 600s;
-        proxy_http_version 1.1;
-        proxy_pass http://backend;
-    }
-
     location / {
-        client_max_body_size 50M;
+        client_max_body_size 100M;
         proxy_set_header Connection "";
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -110,6 +110,21 @@ server {
         proxy_pass http://backend;
     }
 
+    location = /api/v4/files {
+        client_max_body_size 0;
+        client_body_timeout 1200s;
+        proxy_set_header Connection "";
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Frame-Options SAMEORIGIN;
+        proxy_set_header Early-Data $ssl_early_data;
+        proxy_read_timeout 600s;
+        proxy_http_version 1.1;
+        proxy_pass http://backend;
+    }
+
     location / {
         client_max_body_size 50M;
         proxy_set_header Connection "";


### PR DESCRIPTION
This prevents 413 (Request Entity Too Large) errors when uploading large files.

**Key changes:**
- Added a separate location for the file upload endpoint
- Removed request size limit at nginx level (client_max_body_size 0)
- Increased client_body_timeout to support slow/large uploads
- Simplified proxy configuration for this endpoint

**Note:**
File size limits are still enforced at the application level via Mattermost settings, where administrators can configure the maximum allowed upload size.
This change only removes nginx as a limiting factor and delegates control to the application.
<img width="934" height="140" alt="Maximum File Size" src="https://github.com/user-attachments/assets/da308b63-6275-4502-818e-d96916f9f2c4" />
