### PR TITLE
Add automated Let's Encrypt support via certbot

### DIFF
--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -32,6 +32,7 @@ services:
 
   certbot-renew:
     image: certbot/certbot
+    restart: ${RESTART_POLICY}
     profiles: ["acme"]
     depends_on:
       - nginx

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -62,6 +62,7 @@ services:
       - ./certs/var/log/letsencrypt:/var/log/letsencrypt
     environment:
       - DOMAIN=${DOMAIN}
+      - HTTP_PORT=${HTTP_PORT}
     ports:
       - ${HTTP_PORT}:${HTTP_PORT}
     entrypoint: |
@@ -70,7 +71,7 @@ services:
           echo 'Certificate already exists for $DOMAIN';
           exit 0;
         fi;
-        certbot certonly --standalone --http-01-port $HTTP_PORT -d $DOMAIN --agree-tos --non-interactive;
+        certbot certonly --standalone --http-01-port $HTTP_PORT -d $DOMAIN --register-unsafely-without-email --agree-tos --non-interactive;
       "
 
 # Shared volume for Let's Encrypt certificate renewal with a webroot

--- a/docker-compose.nginx.yml
+++ b/docker-compose.nginx.yml
@@ -30,6 +30,49 @@ services:
       - ${CALLS_PORT}:${CALLS_PORT}/udp
       - ${CALLS_PORT}:${CALLS_PORT}/tcp
 
+  certbot-renew:
+    image: certbot/certbot
+    profiles: ["acme"]
+    depends_on:
+      - nginx
+    ## Required to reload nginx via kill -HUP 1
+    pid: "service:nginx"
+    volumes:
+      - ./certs/etc/letsencrypt:/etc/letsencrypt
+      - ./certs/var/lib/letsencrypt:/var/lib/letsencrypt
+      - ./certs/var/log/letsencrypt:/var/log/letsencrypt
+      - shared-webroot:/webroot
+    environment:
+      - DOMAIN=${DOMAIN}
+    entrypoint: |
+      sh -c "
+        while true; do
+          certbot renew --cert-name $DOMAIN --webroot-path /webroot --deploy-hook 'kill -HUP 1';
+          echo 'Sleeping 24h...';
+          sleep 24h;
+        done
+      "
+
+  certbot-init:
+    image: certbot/certbot
+    profiles: ["acme-init"]
+    volumes:
+      - ./certs/etc/letsencrypt:/etc/letsencrypt
+      - ./certs/var/lib/letsencrypt:/var/lib/letsencrypt
+      - ./certs/var/log/letsencrypt:/var/log/letsencrypt
+    environment:
+      - DOMAIN=${DOMAIN}
+    ports:
+      - ${HTTP_PORT}:${HTTP_PORT}
+    entrypoint: |
+      sh -c "
+        if [ -d /etc/letsencrypt/live/$DOMAIN ]; then
+          echo 'Certificate already exists for $DOMAIN';
+          exit 0;
+        fi;
+        certbot certonly --standalone --http-01-port $HTTP_PORT -d $DOMAIN --agree-tos --non-interactive;
+      "
+
 # Shared volume for Let's Encrypt certificate renewal with a webroot
 volumes:
   shared-webroot:

--- a/env.example
+++ b/env.example
@@ -38,9 +38,21 @@ NGINX_DHPARAMS_FILE=./nginx/dhparams4096.pem
 
 CERT_PATH=./volumes/web/cert/cert.pem
 KEY_PATH=./volumes/web/cert/key-no-password.pem
-#GITLAB_PKI_CHAIN_PATH=<path_to_your_gitlab_pki>/pki_chain.pem
+## To use Let's Encrypt certificates, first run:
+## `docker compose -f docker-compose.yml -f docker-compose.nginx.yml --profile acme-init up certbot-init`
+## (nginx must not be running during the initial certificate request)
+## This generates the initial certificate required by nginx.
+## Then start the full stack (including automatic certificate renewal):
+## `docker compose -f docker-compose.yml -f docker-compose.nginx.yml --profile acme up -d`
 #CERT_PATH=./certs/etc/letsencrypt/live/${DOMAIN}/fullchain.pem
 #KEY_PATH=./certs/etc/letsencrypt/live/${DOMAIN}/privkey.pem
+
+## GitLab SSO (optional)
+## Provide GitLab PKI chain to avoid "certificate signed by unknown authority" errors
+## See:
+## https://github.com/mattermost/mattermost-server/issues/13059
+## https://github.com/mattermost/docker/issues/34
+#GITLAB_PKI_CHAIN_PATH=<path_to_your_gitlab_pki>/pki_chain.pem
 
 ## Exposed ports to the host. Inside the container 80, 443 and 8443 will be used
 HTTPS_PORT=443


### PR DESCRIPTION
## Summary

Adds automated Let's Encrypt certificate management using Certbot.

This introduces two optional Docker Compose services:
- `certbot-init` – performs the initial certificate issuance using standalone mode
- `certbot-renew` – runs in the background and periodically renews certificates

Nginx is reloaded automatically after successful renewal using `kill -HUP 1`